### PR TITLE
Remove dynamic dispatch in favor of switch

### DIFF
--- a/jmespath.js
+++ b/jmespath.js
@@ -497,13 +497,14 @@
       },
 
       nud: function(token) {
+        var left;
+        var right;
+        var expression;
         switch (token.type) {
           case "Literal":
             return {type: "Literal", value: token.value};
-            break;
           case "UnquotedIdentifier":
             return {type: "Field", name: token.value};
-            break;
           case "QuotedIdentifier":
             var node = {type: "Field", name: token.value};
             if (this.lookahead(0) === "Lparen") {
@@ -513,12 +514,11 @@
             }
             break;
           case "Not":
-            var right = this.expression(this.bindingPower.Not);
+            right = this.expression(this.bindingPower.Not);
             return {type: "NotExpression", children: [right]};
-            break;
           case "Star":
-            var left = {type: "Identity"};
-            var right = null;
+            left = {type: "Identity"};
+            right = null;
             if (this.lookahead(0) === "Rbracket") {
                 // This can happen in a multiselect,
                 // [a, b, *]
@@ -527,20 +527,15 @@
                 right = this.parseProjectionRHS(this.bindingPower.Star);
             }
             return {type: "ValueProjection", children: [left, right]};
-            break;
           case "Filter":
             return this.led(token.type, {type: "Identity"});
-            break;
           case "Lbrace":
             return this.parseMultiselectHash();
-            break;
           case "Flatten":
-            var left = {type: "Flatten", children: [{type: "Identity"}]};
-            var right = this.parseProjectionRHS(this.bindingPower.Flatten);
+            left = {type: "Flatten", children: [{type: "Identity"}]};
+            right = this.parseProjectionRHS(this.bindingPower.Flatten);
             return {type: "Projection", children: [left, right]};
-            break;
           case "Lbracket":
-            var right;
             if (this.lookahead(0) === "Number" || this.lookahead(0) === "Colon") {
                 right = this.parseIndexExpression();
                 return this.projectIfSlice({type: "Identity"}, right);
@@ -557,14 +552,11 @@
             break;
           case "Current":
             return {type: "Current"};
-            break;
           case "Expref":
-            var expression = this.expression(this.bindingPower.Expref);
+            expression = this.expression(this.bindingPower.Expref);
             return {type: "ExpressionReference", children: [expression]};
-            break;
           case "Lparen":
             var args = [];
-            var expression;
             while (this.lookahead(0) !== "Rparen") {
               if (this.lookahead(0) === "Current") {
                 expression = {type: "Current"};
@@ -576,18 +568,16 @@
             }
             this.match("Rparen");
             return args[0];
-            break;
           default:
             this.errorToken(token);
-            break;
         }
       },
 
       led: function(tokenName, left) {
+        var right;
         switch(tokenName) {
           case "Dot":
             var rbp = this.bindingPower.Dot;
-            var right;
             if (this.lookahead(0) !== "Star") {
                 right = this.parseDotRHS(rbp);
                 return {type: "Subexpression", children: [left, right]};
@@ -599,17 +589,14 @@
             }
             break;
           case "Pipe":
-            var right = this.expression(this.bindingPower.Pipe);
+            right = this.expression(this.bindingPower.Pipe);
             return {type: "Pipe", children: [left, right]};
-            break;
           case "Or":
-            var right = this.expression(this.bindingPower.Or);
+            right = this.expression(this.bindingPower.Or);
             return {type: "OrExpression", children: [left, right]};
-            break;
           case "And":
-            var right = this.expression(this.bindingPower.And);
+            right = this.expression(this.bindingPower.And);
             return {type: "AndExpression", children: [left, right]};
-            break;
           case "Lparen":
             var name = left.name;
             var args = [];
@@ -629,10 +616,8 @@
             this.match("Rparen");
             node = {type: "Function", name: name, children: args};
             return node;
-            break;
           case "Filter":
             var condition = this.expression(0);
-            var right;
             this.match("Rbracket");
             if (this.lookahead(0) === "Flatten") {
               right = {type: "Identity"};
@@ -640,12 +625,10 @@
               right = this.parseProjectionRHS(this.bindingPower.Filter);
             }
             return {type: "FilterProjection", children: [left, right, condition]};
-            break;
           case "Flatten":
             var leftNode = {type: "Flatten", children: [left]};
             var rightNode = this.parseProjectionRHS(this.bindingPower.Flatten);
             return {type: "Projection", children: [leftNode, rightNode]};
-            break;
           case "EQ":
           case "NE":
           case "GT":
@@ -653,10 +636,8 @@
           case "LT":
           case "LTE":
             return this.parseComparator(left, tokenName);
-            break
           case "Lbracket":
             var token = this.lookaheadToken(0);
-            var right;
             if (token.type === "Number" || token.type === "Colon") {
                 right = this.parseIndexExpression();
                 return this.projectIfSlice(left, right);

--- a/jmespath.js
+++ b/jmespath.js
@@ -1677,6 +1677,5 @@
   exports.tokenize = tokenize;
   exports.compile = compile;
   exports.search = search;
-  exports.Parser = Parser;
   exports.strictDeepEqual = strictDeepEqual;
 })(typeof exports === "undefined" ? this.jmespath = {} : exports);

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://github.com/jmespath/jmespath.js",
   "contributors": [],
   "devDependencies": {
-    "grunt": "^0.4.4",
+    "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.11.0",
-    "mocha": "^2.1.0",
-    "grunt-contrib-uglify": "^0.7.0",
-    "grunt-eslint": "^6.0.0"
+    "grunt-contrib-uglify": "^0.11.1",
+    "grunt-eslint": "^17.3.1",
+    "mocha": "^2.1.0"
   },
   "dependencies": {},
   "main": "jmespath.js",

--- a/perf.js
+++ b/perf.js
@@ -1,24 +1,23 @@
 var jmespath = require('./jmespath')
-var parser = new jmespath.Parser();
 var Benchmark = require('benchmark');
 var suite = new Benchmark.Suite;
 
 // add tests
 suite.add('Parser#single_expr', function() {
-  parser.parse("foo");
+  jmespath.compile("foo");
 })
 .add('Parser#single_subexpr', function() {
-  parser.parse("foo.bar");
+  jmespath.compile("foo.bar");
 })
 .add('Parser#deeply_nested_50', function() {
-  parser.parse("j49.j48.j47.j46.j45.j44.j43.j42.j41.j40.j39.j38.j37.j36.j35.j34.j33.j32.j31.j30.j29.j28.j27.j26.j25.j24.j23.j22.j21.j20.j19.j18.j17.j16.j15.j14.j13.j12.j11.j10.j9.j8.j7.j6.j5.j4.j3.j2.j1.j0");
+  jmespath.compile("j49.j48.j47.j46.j45.j44.j43.j42.j41.j40.j39.j38.j37.j36.j35.j34.j33.j32.j31.j30.j29.j28.j27.j26.j25.j24.j23.j22.j21.j20.j19.j18.j17.j16.j15.j14.j13.j12.j11.j10.j9.j8.j7.j6.j5.j4.j3.j2.j1.j0");
 
 })
 .add('Parser#deeply_nested_50_index', function() {
-  parser.parse("[49][48][47][46][45][44][43][42][41][40][39][38][37][36][35][34][33][32][31][30][29][28][27][26][25][24][23][22][21][20][19][18][17][16][15][14][13][12][11][10][9][8][7][6][5][4][3][2][1][0]");
+  jmespath.compile("[49][48][47][46][45][44][43][42][41][40][39][38][37][36][35][34][33][32][31][30][29][28][27][26][25][24][23][22][21][20][19][18][17][16][15][14][13][12][11][10][9][8][7][6][5][4][3][2][1][0]");
 })
 .add('Parser#basic_list_projection', function() {
-  parser.parse("foo[*].bar");
+  jmespath.compile("foo[*].bar");
 })
 .on('cycle', function(event) {
   var bench = event.target;


### PR DESCRIPTION
This PR pulls in a portion of the commits from (https://github.com/jmespath/jmespath.js/tree/reduce-size), which is work done to reduce the minified file size.

I'm not 100% sold on the commits from the `reduce-size` branch, so I've split parts of that branch into this PR, which represents commits I'm ok with merging to master.

The high level change is to switch from dynamic dispatch based on type names to a big switch statement.  This gives two benefits:

* Faster execution time
* Small minified (uncompressed) file size.

Benchmarks from master vs. this PR:

#### master branch

```
$ node perf.js
Mean time: 0.002411msec Parser#single_expr x 414,688 ops/sec ±1.62% (93 runs sampled)
Mean time: 0.005547msec Parser#single_subexpr x 180,273 ops/sec ±1.54% (93 runs sampled)
Mean time: 0.119469msec Parser#deeply_nested_50 x 8,370 ops/sec ±1.74% (91 runs sampled)
Mean time: 0.140929msec Parser#deeply_nested_50_index x 7,096 ops/sec ±1.79% (92 runs sampled)
Mean time: 0.008148msec Parser#basic_list_projection x 122,732 ops/sec ±1.94% (93 runs sampled)
```

#### perf-improve branch

```
$ node perf.js
Mean time: 0.002136msec Parser#single_expr x 468,057 ops/sec ±1.45% (95 runs sampled)
Mean time: 0.004363msec Parser#single_subexpr x 229,209 ops/sec ±1.97% (90 runs sampled)
Mean time: 0.080628msec Parser#deeply_nested_50 x 12,403 ops/sec ±1.52% (89 runs sampled)
Mean time: 0.076382msec Parser#deeply_nested_50_index x 13,092 ops/sec ±7.08% (88 runs sampled)
Mean time: 0.003640msec Parser#basic_list_projection x 274,699 ops/sec ±1.58% (96 runs sampled)
```

Minified file sizes:

* master: `23179` bytes
* perf-improve: `22037` bytes