### PR TITLE
Allow reusing parser result across different searches.

### DIFF
--- a/jmespath.js
+++ b/jmespath.js
@@ -1649,19 +1649,26 @@
   }
 
   function search(data, expression) {
-      var parser = new Parser();
+      return searcher(expression)(data);
+  }
+
+  function searcher(expression){
       // This needs to be improved.  Both the interpreter and runtime depend on
       // each other.  The runtime needs the interpreter to support exprefs.
       // There's likely a clean way to avoid the cyclic dependency.
       var runtime = new Runtime();
       var interpreter = new TreeInterpreter(runtime);
       runtime._interpreter = interpreter;
+      var parser = new Parser();
       var node = parser.parse(expression);
-      return interpreter.search(node, data);
+      return function(data){
+          return interpreter.search(node, data);
+      }
   }
 
   exports.tokenize = tokenize;
   exports.compile = compile;
   exports.search = search;
+  exports.searcher = searcher;
   exports.strictDeepEqual = strictDeepEqual;
 })(typeof exports === "undefined" ? this.jmespath = {} : exports);


### PR DESCRIPTION
The API exposed by the module does not allow to cache `Parser.parse` results to be _reused_ across subsequent searches. One use case is to easily apply single projection over many json documents fetched as i.e. database rows using streaming API. Reusing the parse result would also result in performance improvement.

This pull request is a proposal of an API to achieve that:
```javascript
const jmespath = require('jmespath');
const projection = jmespath.searcher('products[*].name');
const projectedRows = query().map(row => projection(row));
```