### PR TITLE
Add a type table for function argument mismatch error messages

### DIFF
--- a/jmespath.js
+++ b/jmespath.js
@@ -140,6 +140,18 @@
   var TYPE_NULL = 7;
   var TYPE_ARRAY_NUMBER = 8;
   var TYPE_ARRAY_STRING = 9;
+  var TYPE_NAME_TABLE = {
+    0: 'number',
+    1: 'any',
+    2: 'string',
+    3: 'array',
+    4: 'object',
+    5: 'boolean',
+    6: 'expression',
+    7: 'null',
+    8: 'Array<number>',
+    9: 'Array<string>'
+  };
 
   var TOK_EOF = "EOF";
   var TOK_UNQUOTEDIDENTIFIER = "UnquotedIdentifier";
@@ -1237,11 +1249,16 @@
                 }
             }
             if (!typeMatched) {
+                var expected = currentSpec
+                    .map(function(typeIdentifier) {
+                        return TYPE_NAME_TABLE[typeIdentifier];
+                    })
+                    .join(',');
                 throw new Error("TypeError: " + name + "() " +
                                 "expected argument " + (i + 1) +
-                                " to be type " + currentSpec +
-                                " but received type " + actualType +
-                                " instead.");
+                                " to be type " + expected +
+                                " but received type " +
+                                TYPE_NAME_TABLE[actualType] + " instead.");
             }
         }
     },

--- a/test/jmespath.js
+++ b/test/jmespath.js
@@ -160,6 +160,7 @@ describe('tokenize', function() {
             ]
         );
     });
+
 });
 
 
@@ -214,4 +215,20 @@ describe('strictDeepEqual', function() {
             strictDeepEqual({a: {b: [1, 2]}},
                             {a: {b: [1, 4]}}), false);
     });
+});
+
+describe('search', function() {
+    it(
+        'should throw a readable error when invalid arguments are provided to a function',
+        function() {
+            try {
+                jmespath.search([], 'length(`null`)');
+            } catch (e) {
+                assert(e.message.search(
+                    'expected argument 1 to be type string,array,object'
+                ), e.message);
+                assert(e.message.search('received type null'), e.message);
+            }
+        }
+    );
 });


### PR DESCRIPTION
Fixes #28.

Type mismatch error messages refer to types by the value of the constant used to identify them internally, which can be pretty confusing. This PR adds a constant to string mapping so that the messages can be read on their own.