### PR TITLE
Allow addition of custom functions via decorate()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 /yarn.lock
+package-lock.json
+.idea

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ through a JMESPath expression.
 Using jmespath.js is really easy.  There's a single function
 you use, `jmespath.search`:
 
+```js
+var jmespath = require('jmespath');
+jmespath.search({foo: {bar: {baz: [0, 1, 2, 3, 4]}}}, "foo.bar.baz[2]")
 
-```
-> var jmespath = require('jmespath');
-> jmespath.search({foo: {bar: {baz: [0, 1, 2, 3, 4]}}}, "foo.bar.baz[2]")
-2
+// output = 2
 ```
 
 In the example we gave the ``search`` function input data of
@@ -25,20 +25,61 @@ the expression against the input data to produce the result ``2``.
 The JMESPath language can do a lot more than select an element
 from a list.  Here are a few more examples:
 
-```
-> jmespath.search({foo: {bar: {baz: [0, 1, 2, 3, 4]}}}, "foo.bar")
-{ baz: [ 0, 1, 2, 3, 4 ] }
+```js
+jmespath.search({foo: {bar: {baz: [0, 1, 2, 3, 4]}}}, "foo.bar")
 
-> jmespath.search({"foo": [{"first": "a", "last": "b"},
+// { baz: [ 0, 1, 2, 3, 4 ] }
+
+jmespath.search({"foo": [{"first": "a", "last": "b"},
                            {"first": "c", "last": "d"}]},
                   "foo[*].first")
-[ 'a', 'c' ]
 
-> jmespath.search({"foo": [{"age": 20}, {"age": 25},
+// [ 'a', 'c' ]
+
+jmespath.search({"foo": [{"age": 20}, {"age": 25},
                            {"age": 30}, {"age": 35},
                            {"age": 40}]},
                   "foo[?age > `30`]")
-[ { age: 35 }, { age: 40 } ]
+
+// [ { age: 35 }, { age: 40 } ]
+```
+
+## Adding custom functions
+
+Custom functions can be added to the JMESPath runtime by using the
+`decorate()` function:
+
+```js
+var TYPE_NUMBER = 0;
+function customFunc(resolvedArgs) {
+  return resolvedArgs[0] + 99;
+}
+var extraFunctions = {
+  custom: {_func: customFunc, _signature: [{types: [TYPE_NUMBER]}]},
+};
+jmespath.decorate(extraFunctions);
+```
+
+The value returned by the decorate function is a curried function
+(takes arguments one at a time) that takes the search expression 
+first and then the data to search against as the second parameter:
+
+```js
+var value = jmespath.decorate(extraFunctions)('custom(`1`)')({})
+// value = 100
+```
+
+Because the return value from `decorate()` is a curried function
+the result of compiling the expression can be cached and run 
+multiple times against different data:
+
+```js
+var expr = jmespath.decorate({})('a');
+// expr is now a cached compiled version of the search expression
+var value = expr({ a: 1 });
+assert.strictEqual(value, 1);
+value = expr({ a: 2 });
+assert.strictEqual(value, 2);
 ```
 
 ## More Resources

--- a/jmespath.js
+++ b/jmespath.js
@@ -212,6 +212,7 @@
   var skipChars = {
       " ": true,
       "\t": true,
+      "\r": true,
       "\n": true
   };
 

--- a/jmespath.js
+++ b/jmespath.js
@@ -806,7 +806,7 @@
               right = this._parseDotRHS(rbp);
           } else {
               var t = this._lookaheadToken(0);
-              var error = new Error("Sytanx error, unexpected token: " +
+              var error = new Error("Syntax error, unexpected token: " +
                                     t.value + "(" + t.type + ")");
               error.name = "ParserError";
               throw error;

--- a/jmespath.js
+++ b/jmespath.js
@@ -1654,19 +1654,27 @@
   }
 
   function search(data, expression) {
+      return decorate({})(data, expression);
+  }
+
+  function decorate(fns) {
       var parser = new Parser();
       // This needs to be improved.  Both the interpreter and runtime depend on
       // each other.  The runtime needs the interpreter to support exprefs.
       // There's likely a clean way to avoid the cyclic dependency.
       var runtime = new Runtime();
+      Object.assign(runtime.functionTable, fns);
       var interpreter = new TreeInterpreter(runtime);
       runtime._interpreter = interpreter;
-      var node = parser.parse(expression);
-      return interpreter.search(node, data);
+      return function(data, expression) {
+          var node = parser.parse(expression);
+          return interpreter.search(node, data);
+      }
   }
 
   exports.tokenize = tokenize;
   exports.compile = compile;
   exports.search = search;
+  exports.decorate = decorate;
   exports.strictDeepEqual = strictDeepEqual;
 })(typeof exports === "undefined" ? this.jmespath = {} : exports);

--- a/jmespath.js
+++ b/jmespath.js
@@ -1654,7 +1654,7 @@
   }
 
   function search(data, expression) {
-      return decorate({})(data, expression);
+      return decorate({})(expression)(data);
   }
 
   function decorate(fns) {
@@ -1666,9 +1666,11 @@
       Object.assign(runtime.functionTable, fns);
       var interpreter = new TreeInterpreter(runtime);
       runtime._interpreter = interpreter;
-      return function(data, expression) {
-          var node = parser.parse(expression);
+      return function (expression) {
+        var node = parser.parse(expression);
+        return function (data) {
           return interpreter.search(node, data);
+        }
       }
   }
 

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://github.com/jmespath/jmespath.js",
   "contributors": [],
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-contrib-jshint": "^0.11.0",
+    "grunt": "^1.0.4",
+    "grunt-contrib-jshint": "^2.1.0",
     "grunt-contrib-uglify": "^0.11.1",
-    "grunt-eslint": "^17.3.1",
-    "mocha": "^2.1.0"
+    "grunt-eslint": "^22.0.0",
+    "mocha": "^7.1.0"
   },
   "dependencies": {},
   "main": "jmespath.js",

--- a/test/jmespath.js
+++ b/test/jmespath.js
@@ -244,8 +244,18 @@ describe('decorate', function() {
       var extraFunctions = {
         custom: {_func: customFunc, _signature: [{types: [TYPE_NUMBER]}]},
       };
-      var value = jmespath.decorate(extraFunctions)([], 'custom(`1`)');
+      var value = jmespath.decorate(extraFunctions)('custom(`1`)')({});
       assert.strictEqual(value, 100);
+    }
+  );
+  it(
+    'should provide a compiled expression that can be cached and reused',
+    function() {
+      var expr = jmespath.decorate({})('a');
+      var value = expr({ a: 1 });
+      assert.strictEqual(value, 1);
+      value = expr({ a: 2 });
+      assert.strictEqual(value, 2);
     }
   );
 });

--- a/test/jmespath.js
+++ b/test/jmespath.js
@@ -232,3 +232,20 @@ describe('search', function() {
         }
     );
 });
+
+describe('decorate', function() {
+  it(
+    'should call a custom function when called via decorator',
+    function() {
+      var TYPE_NUMBER = 0;
+      function customFunc(resolvedArgs) {
+        return resolvedArgs[0] + 99;
+      }
+      var extraFunctions = {
+        custom: {_func: customFunc, _signature: [{types: [TYPE_NUMBER]}]},
+      };
+      var value = jmespath.decorate(extraFunctions)([], 'custom(`1`)');
+      assert.strictEqual(value, 100);
+    }
+  );
+});


### PR DESCRIPTION
This pull request contains various fixes I have made:

- npm audit fix
- allow addition of custom functions 
- allow caching of compiled expressions
- a couple of minor changes proposed in other PRs

The main difference is that I've added a `decorate()` function.  

The decorate function allows you to add entries to the runtime's built in function table. The return value from this decorate function is a curried function (takes arguments one at a time) that takes the search expression and then the data to search. Because it's curried it means you can cache the parsed expression and run it against multiple data sets. 

PR includes basic tests for the `decorate()` function.