### PR TITLE
Create `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+test/
+*.*
+!*.js
+!*.json
+pref.js
+Gruntfile.js
+BASELINE


### PR DESCRIPTION
The latest published version of this package is about ~210kb in size, most of which is because `test` is included in the published package (taking up ~126kb).

This adds a `.npmignore` file that ignores `test` & every file unless it ends with `.js` or `.json`, along with a select few other files that don't need to be published.

I suspect a few of the .js files can be ignored as well, but don't know the library well enough to want to risk blocking ignoring `test` due to risk of breaking downstream users.

Note that npm *always* includes `package.json`, `LICENSE`, `README.md`, and a few other files regardless of if they're matched by any ignore file, so these will always be included in the package.

Ideally it would be great if this could actually get published after being merged, since it's used by the `aws-sdk` which is a super popular package - while dropping ~150kb off the package size might not seem like a lot of saved space, it adds up quickly if you consider how often CIs re-download packages, multiple cache storage layers across the world, etc

It's a cheap & easy small win that costs next to nothing :)